### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # npm-search MCP Server
+[![smithery badge](https://smithery.ai/badge/npm-search-mcp-server)](https://smithery.ai/server/npm-search-mcp-server)
 
 A Model Context Protocol server that allows you to search for npm packages by calling the `npm search` command.
 
@@ -11,6 +12,14 @@ A Model Context Protocol server that allows you to search for npm packages by ca
 ![Claude Screenshot](./screenshot.png)
 
 ## Installation
+
+### Installing via Smithery
+
+To install npm-search for Claude Desktop automatically via [Smithery](https://smithery.ai/server/npm-search-mcp-server):
+
+```bash
+npx -y @smithery/cli install npm-search-mcp-server --client claude
+```
 
 ### Using NPM (recommended)
 


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install NPM Search for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/npm-search-mcp-server

Let me know if any tweaks have to be made!